### PR TITLE
tx hash endpoint and snake_case

### DIFF
--- a/rollup-aggregator-server/app/Main.hs
+++ b/rollup-aggregator-server/app/Main.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import Options.Applicative
+
 import ZkFold.Cardano.Rollup.Aggregator.Options
 
 main ∷ IO ()

--- a/rollup-aggregator-server/scripts/Seed.hs
+++ b/rollup-aggregator-server/scripts/Seed.hs
@@ -12,9 +12,6 @@ import GeniusYield.Types
 import Options.Applicative
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (takeDirectory)
-import ZkFold.Cardano.Rollup.Aggregator.Batcher (initialState)
-import ZkFold.Cardano.Rollup.Aggregator.Persistence (initDb, saveState)
-import ZkFold.Cardano.Rollup.Aggregator.Types
 import ZkFold.Cardano.Rollup.Api
 import ZkFold.Cardano.Rollup.Api.Utils (stateToRollupState)
 import ZkFold.Cardano.Rollup.Types
@@ -25,6 +22,10 @@ import ZkFold.Symbolic.Ledger.Circuit.Compile (
   mkSetup,
  )
 import ZkFold.Symbolic.Ledger.Types (nullUTxO)
+
+import ZkFold.Cardano.Rollup.Aggregator.Batcher (initialState)
+import ZkFold.Cardano.Rollup.Aggregator.Persistence (initDb, saveState)
+import ZkFold.Cardano.Rollup.Aggregator.Types
 
 main ∷ IO ()
 main = runCommand =<< execParser opts

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Api.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Api.hs
@@ -19,9 +19,12 @@ import Data.Text qualified as T
 import Data.Version (showVersion)
 import GHC.Natural (Natural)
 import GeniusYield.Types (GYAddressBech32)
-import PackageInfo_rollup_aggregator_server qualified as PackageInfo
 import Servant
 import Servant.OpenApi
+import ZkFold.Symbolic.Data.FieldElement (FieldElement)
+import ZkFold.Symbolic.Ledger.Types.Field (RollupBFInterpreter)
+
+import PackageInfo_rollup_aggregator_server qualified as PackageInfo
 import ZkFold.Cardano.Rollup.Aggregator.Auth
 import ZkFold.Cardano.Rollup.Aggregator.Orphans ()
 import ZkFold.Cardano.Rollup.Aggregator.SwaggerUI (SwaggerUIAPI)
@@ -31,6 +34,8 @@ import ZkFold.Cardano.Rollup.Aggregator.Types (
   BridgeInRequest,
   BridgeInResponse,
   BridgeOutsResponse,
+  ConvertAddressRequest,
+  ConvertAddressResponse,
   PendingTxsResponse,
   QueryL2UtxosResponse,
   StateInfoResponse,
@@ -38,21 +43,19 @@ import ZkFold.Cardano.Rollup.Aggregator.Types (
   SubmitL1TxResponse,
   SubmitTxRequest,
   SubmitTxResponse,
-  TxResponse,
-  TxsByAddressResponse,
   TxHashRequest,
   TxHashResponse,
   TxParametersResponse,
+  TxResponse,
+  TxsByAddressResponse,
  )
-import ZkFold.Symbolic.Data.FieldElement (FieldElement)
-import ZkFold.Symbolic.Ledger.Types.Field (RollupBFInterpreter)
 
 -- | Health check endpoint.
 type HealthAPI =
   Summary "Health check"
     :> Description
-        "Returns 200 OK when the server is operational. \
-        \Use this endpoint to verify the service is reachable before submitting transactions."
+         "Returns 200 OK when the server is operational. \
+         \Use this endpoint to verify the service is reachable before submitting transactions."
     :> "health"
     :> Get '[JSON] ()
 
@@ -60,9 +63,9 @@ type HealthAPI =
 type SubmitTxAPI =
   Summary "Submit L2 transaction"
     :> Description
-        "Enqueue a signed L2 transaction for batching. \
-        \The transaction is validated (bridge-out count, addresses, and values are checked) \
-        \then stored with status 'pending' until the batcher picks it up."
+         "Enqueue a signed L2 transaction for batching. \
+         \The transaction is validated (bridge-out count, addresses, and values are checked) \
+         \then stored with status 'pending' until the batcher picks it up."
     :> "tx"
     :> ReqBody '[JSON] SubmitTxRequest
     :> Post '[JSON] SubmitTxResponse
@@ -70,23 +73,45 @@ type SubmitTxAPI =
 type BridgeInAPI =
   Summary "Build bridge-in transaction"
     :> Description
-        "Construct an unsigned L1 transaction that deposits ADA or native tokens into the rollup \
-        \at a given L2 address. The returned transaction must be signed and submitted via \
-        \POST /v0/l1/tx/submit."
+         "Construct an unsigned L1 transaction that deposits ADA or native tokens into the rollup \
+         \at a given L2 address. The returned transaction must be signed and submitted via \
+         \POST /v0/l1/tx/submit."
     :> "bridge"
     :> "in"
     :> ReqBody '[JSON] BridgeInRequest
     :> Post '[JSON] BridgeInResponse
 
-type TxHashAPI = "tx" :> "hash" :> ReqBody '[JSON] TxHashRequest :> Post '[JSON] TxHashResponse
+type ConvertAddressAPI =
+  Summary "Convert Cardano address into a dummy L2 address"
+    :> Description
+         "In bridge-out transactions, the L2 address in the transaction outputs must be obtained from \
+         \an L1 Cardano address using this endpoint. \
+         \The resulting L2 address will only be a dummy address and must not be used anywhere other than bridge-out transactions."
+    :> "l1"
+    :> "address"
+    :> "convert"
+    :> ReqBody '[JSON] ConvertAddressRequest
+    :> Post '[JSON] ConvertAddressResponse
 
-type TxParametersAPI = "tx" :> "parameters" :> Get '[JSON] TxParametersResponse
+type TxHashAPI =
+  Summary "Get hash of an L2 transaction"
+    :> "tx"
+    :> "hash"
+    :> ReqBody '[JSON] TxHashRequest
+    :> Post '[JSON] TxHashResponse
+
+type TxParametersAPI =
+  Summary "Obtain transaction parameters"
+    :> Description "Obtain the supported number of inputs, outputs and assets in L2 trasactions."
+    :> "tx"
+    :> "parameters"
+    :> Get '[JSON] TxParametersResponse
 
 type SubmitL1TxAPI =
   Summary "Submit signed L1 transaction"
     :> Description
-        "Attach a witness to a previously built L1 transaction (e.g. a bridge-in) \
-        \and submit it to the Cardano network."
+         "Attach a witness to a previously built L1 transaction (e.g. a bridge-in) \
+         \and submit it to the Cardano network."
     :> "l1"
     :> "tx"
     :> "submit"
@@ -106,8 +131,8 @@ type StateInfoAPI =
 type QueryL2UtxosAPI =
   Summary "Query L2 UTxOs by address"
     :> Description
-        "Return all unspent transaction outputs at the given L2 address \
-        \according to the latest persisted ledger state."
+         "Return all unspent transaction outputs at the given L2 address \
+         \according to the latest persisted ledger state."
     :> "utxos"
     :> QueryParam' '[Required, Strict] "address" (FieldElement RollupBFInterpreter)
     :> Get '[JSON] QueryL2UtxosResponse
@@ -116,9 +141,9 @@ type QueryL2UtxosAPI =
 type GetTxAPI =
   Summary "Get transaction by hash"
     :> Description
-        "Retrieve a single queued transaction by its hash (the JSON-encoded txId field element), \
-        \including its current processing status ('pending', 'processing', or 'batched') \
-        \and the batch it was included in, if any."
+         "Retrieve a single queued transaction by its hash (the JSON-encoded txId field element), \
+         \including its current processing status ('pending', 'processing', or 'batched') \
+         \and the batch it was included in, if any."
     :> "tx"
     :> Capture "hash" Text
     :> Get '[JSON] TxResponse
@@ -127,8 +152,8 @@ type GetTxAPI =
 type PendingTxsAPI =
   Summary "List pending transactions"
     :> Description
-        "Return all transactions currently waiting to be included in the next batch \
-        \(status = 'pending')."
+         "Return all transactions currently waiting to be included in the next batch \
+         \(status = 'pending')."
     :> "txs"
     :> "pending"
     :> Get '[JSON] PendingTxsResponse
@@ -137,10 +162,10 @@ type PendingTxsAPI =
 type TxsByAddressAPI =
   Summary "Transaction history for L2 address"
     :> Description
-        "Return a paginated list of all transactions that involve the given L2 address, \
-        \either as a recipient of an output or as a sender (i.e. one of the transaction's \
-        \inputs was previously locked at that address), ordered newest first. \
-        \Defaults: limit = 20, offset = 0."
+         "Return a paginated list of all transactions that involve the given L2 address, \
+         \either as a recipient of an output or as a sender (i.e. one of the transaction's \
+         \inputs was previously locked at that address), ordered newest first. \
+         \Defaults: limit = 20, offset = 0."
     :> "txs"
     :> QueryParam' '[Required, Strict] "l2address" (FieldElement RollupBFInterpreter)
     :> QueryParam "limit" Natural
@@ -151,9 +176,9 @@ type TxsByAddressAPI =
 type GetBatchAPI =
   Summary "Get batch by ID"
     :> Description
-        "Retrieve a single batch record by its database ID, \
-        \including the L1 transaction hash and the full list of L2 transactions \
-        \bundled in that batch."
+         "Retrieve a single batch record by its database ID, \
+         \including the L1 transaction hash and the full list of L2 transactions \
+         \bundled in that batch."
     :> "batch"
     :> Capture "id" Natural
     :> Get '[JSON] BatchDetailResponse
@@ -162,9 +187,9 @@ type GetBatchAPI =
 type BatchesAPI =
   Summary "List batches"
     :> Description
-        "Return a paginated list of submitted batches, ordered newest first. \
-        \Each entry includes the L1 transaction hash and the number of L2 transactions bundled. \
-        \Defaults: limit = 20, offset = 0."
+         "Return a paginated list of submitted batches, ordered newest first. \
+         \Each entry includes the L1 transaction hash and the number of L2 transactions bundled. \
+         \Defaults: limit = 20, offset = 0."
     :> "batches"
     :> QueryParam "limit" Natural
     :> QueryParam "offset" Natural
@@ -175,11 +200,11 @@ type BridgeOutsAPI =
   Summary "List bridge-outs for L1 address"
     -- TODO: Need to improve description.
     :> Description
-        "Return all bridge-out entries destined for the given L1 bech32 address. \
-        \A bridge-out with status 'pending' or 'processing' is waiting to be included in a batch. \
-        \Once the batch proof is submitted on L1, the bridge-out outputs are delivered directly \
-        \to the recipient address as outputs of that same L1 transaction — no further action \
-        \is required from the user."
+         "Return all bridge-out entries destined for the given L1 bech32 address. \
+         \A bridge-out with status 'pending' or 'processing' is waiting to be included in a batch. \
+         \Once the batch proof is submitted on L1, the bridge-out outputs are delivered directly \
+         \to the recipient address as outputs of that same L1 transaction — no further action \
+         \is required from the user."
     :> "bridge"
     :> "out"
     :> QueryParam' '[Required, Strict] "l1address" GYAddressBech32
@@ -188,6 +213,7 @@ type BridgeOutsAPI =
 -- | V0 API - combines all endpoints.
 type V0API =
   HealthAPI
+    :<|> ConvertAddressAPI
     :<|> SubmitTxAPI
     :<|> TxHashAPI
     :<|> TxParametersAPI
@@ -235,12 +261,12 @@ aggregatorAPIOpenApi =
     & OpenApi.info
       . OpenApi.contact
       ?~ ( mempty
-            & OpenApi.url
-              ?~ OpenApi.URL "https://zkfold.io/"
-            & OpenApi.email
-              ?~ "info@zkfold.io"
-            & OpenApi.name
-              ?~ "zkFold Technical Support"
+             & OpenApi.url
+               ?~ OpenApi.URL "https://zkfold.io/"
+             & OpenApi.email
+               ?~ "info@zkfold.io"
+             & OpenApi.name
+               ?~ "zkFold Technical Support"
          )
     & OpenApi.info
       . OpenApi.description
@@ -248,6 +274,9 @@ aggregatorAPIOpenApi =
     & OpenApi.applyTagsFor
       (subOperations (Proxy ∷ Proxy (V0 :> HealthAPI)) (Proxy ∷ Proxy AggregatorAPI))
       ["Settings" & OpenApi.description ?~ "Endpoint to check if the server is healthy."]
+    & OpenApi.applyTagsFor
+      (subOperations (Proxy ∷ Proxy (V0 :> ConvertAddressAPI)) (Proxy ∷ Proxy AggregatorAPI))
+      ["Address" & OpenApi.description ?~ "Convert L1 address to a dummy L2 address."]
     & OpenApi.applyTagsFor
       (subOperations (Proxy ∷ Proxy (V0 :> SubmitTxAPI)) (Proxy ∷ Proxy AggregatorAPI))
       ["Transactions" & OpenApi.description ?~ "Submit a single L2 transaction for batching."]

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Api.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Api.hs
@@ -40,6 +40,9 @@ import ZkFold.Cardano.Rollup.Aggregator.Types (
   SubmitTxResponse,
   TxResponse,
   TxsByAddressResponse,
+  TxHashRequest,
+  TxHashResponse,
+  TxParametersResponse,
  )
 import ZkFold.Symbolic.Data.FieldElement (FieldElement)
 import ZkFold.Symbolic.Ledger.Types.Field (RollupBFInterpreter)
@@ -74,6 +77,10 @@ type BridgeInAPI =
     :> "in"
     :> ReqBody '[JSON] BridgeInRequest
     :> Post '[JSON] BridgeInResponse
+
+type TxHashAPI = "tx" :> "hash" :> ReqBody '[JSON] TxHashRequest :> Post '[JSON] TxHashResponse
+
+type TxParametersAPI = "tx" :> "parameters" :> Get '[JSON] TxParametersResponse
 
 type SubmitL1TxAPI =
   Summary "Submit signed L1 transaction"
@@ -182,6 +189,8 @@ type BridgeOutsAPI =
 type V0API =
   HealthAPI
     :<|> SubmitTxAPI
+    :<|> TxHashAPI
+    :<|> TxParametersAPI
     :<|> BridgeInAPI
     :<|> SubmitL1TxAPI
     :<|> StateInfoAPI
@@ -242,6 +251,12 @@ aggregatorAPIOpenApi =
     & OpenApi.applyTagsFor
       (subOperations (Proxy ∷ Proxy (V0 :> SubmitTxAPI)) (Proxy ∷ Proxy AggregatorAPI))
       ["Transactions" & OpenApi.description ?~ "Submit a single L2 transaction for batching."]
+    & OpenApi.applyTagsFor
+      (subOperations (Proxy ∷ Proxy (V0 :> TxHashAPI)) (Proxy ∷ Proxy AggregatorAPI))
+      ["Transactions" & OpenApi.description ?~ "Calculate hash of an L2 transaction."]
+    & OpenApi.applyTagsFor
+      (subOperations (Proxy ∷ Proxy (V0 :> TxParametersAPI)) (Proxy ∷ Proxy AggregatorAPI))
+      ["Transactions" & OpenApi.description ?~ "Obtain current transaction parameters."]
     & OpenApi.applyTagsFor
       (subOperations (Proxy ∷ Proxy (V0 :> BridgeInAPI)) (Proxy ∷ Proxy AggregatorAPI))
       ["Bridge" & OpenApi.description ?~ "Bridge operations."]

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Api.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Api.hs
@@ -82,7 +82,7 @@ type BridgeInAPI =
     :> Post '[JSON] BridgeInResponse
 
 type ConvertAddressAPI =
-  Summary "Convert Cardano address into a dummy L2 address"
+  Summary "Obtain Symbolic representation of a Cardano address"
     :> Description
          "In bridge-out transactions, the L2 address in the transaction outputs must be obtained from \
          \an L1 Cardano address using this endpoint. \
@@ -122,8 +122,8 @@ type SubmitL1TxAPI =
 type StateInfoAPI =
   Summary "Get rollup state info"
     :> Description
-        "Return the current persisted rollup state (chain length, UTxO tree root, etc.), \
-        \or null if the rollup has not been seeded yet."
+         "Return the current persisted rollup state (chain length, UTxO tree root, etc.), \
+         \or null if the rollup has not been seeded yet."
     :> "state"
     :> Get '[JSON] StateInfoResponse
 

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Config.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Config.hs
@@ -51,7 +51,7 @@ data BatchConfig = BatchConfig
   , bcBatchIntervalSeconds ∷ !Natural
   -- ^ How often to create batches (in seconds).
   }
-  deriving stock (Show, Eq, Generic)
+  deriving stock (Eq, Generic, Show)
   deriving
     (FromJSON, ToJSON)
     via CustomJSON '[FieldLabelModifier '[StripPrefix "bc", LowerFirst]] BatchConfig

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Ctx.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Ctx.hs
@@ -34,8 +34,9 @@ import GeniusYield.Types (
   gyLogInfo,
   gyLogWarning,
  )
-import ZkFold.Cardano.Rollup.Aggregator.Config (BatchConfig)
 import ZkFold.Cardano.Rollup.Types (ZKInitializedRollupBuildInfo)
+
+import ZkFold.Cardano.Rollup.Aggregator.Config (BatchConfig)
 
 -- | Server context containing shared configuration for both the server and batcher.
 data Ctx = Ctx

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Handlers.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Handlers.hs
@@ -51,10 +51,9 @@ import ZkFold.Cardano.Rollup.Api
 import ZkFold.Data.Vector (fromVector)
 import ZkFold.Symbolic.Data.Bool (fromBool)
 import ZkFold.Symbolic.Data.FieldElement (FieldElement)
-import ZkFold.Symbolic.Data.Hash (Hashable (..))
+import ZkFold.Symbolic.Data.Hash (hHash)
+import ZkFold.Symbolic.Ledger.Types
 import ZkFold.Symbolic.Ledger.Types.Field (RollupBFInterpreter)
-import ZkFold.Symbolic.Ledger.Types.Transaction.Core (Output (..), Transaction (..))
-import ZkFold.Symbolic.Ledger.Types.Value (AssetValue (..))
 
 import ZkFold.Cardano.Rollup.Aggregator.Api (AggregatorAPI)
 import ZkFold.Cardano.Rollup.Aggregator.Batcher (enqueueTx)
@@ -154,7 +153,7 @@ handleSubmitTx ctx SubmitTxRequest {..} = do
 handleTxHash ∷ Ctx → TxHashRequest → IO TxHashResponse
 handleTxHash _ctx TxHashRequest {..} = pure $ TxHashResponse {..}
  where
-  thrHash = hasher thrTransaction
+  thrHash = hHash . txId $ thrTransaction
 
 handleTxParameters ∷ Ctx → IO TxParametersResponse
 handleTxParameters _ctx = pure txParameters
@@ -193,8 +192,8 @@ handleBridgeIn ctx BridgeInRequest {..} = do
 handleSubmitL1Tx ∷ Ctx → SubmitL1TxRequest → IO SubmitL1TxResponse
 handleSubmitL1Tx ctx SubmitL1TxRequest {..} = do
   let txWithWitness = appendWitnessGYTx sl1trWitness sl1trTransaction
-  txId ← gySubmitTx (ctxProviders ctx) txWithWitness
-  pure $ SubmitL1TxResponse txId
+  submittedTxId ← gySubmitTx (ctxProviders ctx) txWithWitness
+  pure $ SubmitL1TxResponse submittedTxId
 
 -- | Handle rollup state info query.
 handleStateInfo ∷ Ctx → IO StateInfoResponse

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Handlers.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Handlers.hs
@@ -4,6 +4,7 @@ module ZkFold.Cardano.Rollup.Aggregator.Handlers (
 
   -- * Individual Handlers
   handleHealth,
+  handleConvertAddress,
   handleSubmitTx,
   handleTxHash,
   handleBridgeIn,
@@ -46,6 +47,15 @@ import PlutusLedgerApi.V1.Value (CurrencySymbol (..), TokenName (..))
 import PlutusLedgerApi.V1.Value qualified as Plutus
 import Servant (ServerError (..), ServerT, err400, err404, (:<|>) (..))
 import ZkFold.Algebra.Class (fromConstant, one)
+import ZkFold.Cardano.Rollup.Api
+import ZkFold.Data.Vector (fromVector)
+import ZkFold.Symbolic.Data.Bool (fromBool)
+import ZkFold.Symbolic.Data.FieldElement (FieldElement)
+import ZkFold.Symbolic.Data.Hash (Hashable (..))
+import ZkFold.Symbolic.Ledger.Types.Field (RollupBFInterpreter)
+import ZkFold.Symbolic.Ledger.Types.Transaction.Core (Output (..), Transaction (..))
+import ZkFold.Symbolic.Ledger.Types.Value (AssetValue (..))
+
 import ZkFold.Cardano.Rollup.Aggregator.Api (AggregatorAPI)
 import ZkFold.Cardano.Rollup.Aggregator.Batcher (enqueueTx)
 import ZkFold.Cardano.Rollup.Aggregator.Ctx (
@@ -68,6 +78,8 @@ import ZkFold.Cardano.Rollup.Aggregator.Types (
   BridgeInRequest (..),
   BridgeInResponse (..),
   BridgeOutsResponse (..),
+  ConvertAddressRequest (..),
+  ConvertAddressResponse (..),
   I,
   PendingTxsResponse (..),
   QueryL2UtxosResponse (..),
@@ -77,26 +89,19 @@ import ZkFold.Cardano.Rollup.Aggregator.Types (
   SubmitL1TxResponse (..),
   SubmitTxRequest (..),
   SubmitTxResponse (..),
-  TxResponse (..),
-  TxsByAddressResponse (..),
   TxHashRequest (..),
   TxHashResponse (..),
   TxParametersResponse (..),
+  TxResponse (..),
+  TxsByAddressResponse (..),
   txParameters,
  )
-import ZkFold.Cardano.Rollup.Api
-import ZkFold.Data.Vector (fromVector)
-import ZkFold.Symbolic.Data.Bool (fromBool)
-import ZkFold.Symbolic.Data.FieldElement (FieldElement)
-import ZkFold.Symbolic.Data.Hash (Hashable (..))
-import ZkFold.Symbolic.Ledger.Types.Field (RollupBFInterpreter)
-import ZkFold.Symbolic.Ledger.Types.Transaction.Core (Output (..), Transaction (..))
-import ZkFold.Symbolic.Ledger.Types.Value (AssetValue (..))
 
 -- | Server implementation for the aggregator API.
 aggregatorServer ∷ Ctx → ServerT AggregatorAPI IO
 aggregatorServer ctx =
   handleHealth ctx
+    :<|> handleConvertAddress ctx
     :<|> handleSubmitTx ctx
     :<|> handleTxHash ctx
     :<|> handleTxParameters ctx
@@ -114,6 +119,15 @@ aggregatorServer ctx =
 -- | Handle health check requests.
 handleHealth ∷ Ctx → IO ()
 handleHealth _ctx = pure ()
+
+handleConvertAddress ∷ Ctx → ConvertAddressRequest → IO ConvertAddressResponse
+handleConvertAddress _ ConvertAddressRequest {..} = pure $ ConvertAddressResponse $ bech32ToFE carAddress
+
+bech32ToFE ∷ GYAddressBech32 → FieldElement RollupBFInterpreter
+bech32ToFE addrBech32 = expectedAddrFe
+ where
+  addr = addressFromBech32 addrBech32
+  expectedAddrFe = fromConstant $ byteStringToInteger' $ addressToBS $ addressToPlutus addr
 
 -- | Handle L2 transaction submission.
 handleSubmitTx ∷ Ctx → SubmitTxRequest → IO SubmitTxResponse
@@ -133,20 +147,17 @@ handleSubmitTx ctx SubmitTxRequest {..} = do
               txHash ← enqueueTx ctx $ QueuedTx strTransaction strSignatures bridgeOutPairs
               pure $ SubmitTxResponse "queued" txHash
  where
-  validateAddr (out :*: _, (_, addrBech32)) =
-    let addr = addressFromBech32 addrBech32
-        expectedAddrFe = fromConstant $ byteStringToInteger' $ addressToBS $ addressToPlutus addr
-     in expectedAddrFe == oAddress out
+  validateAddr (out :*: _, (_, addrBech32)) = bech32ToFE addrBech32 == oAddress out
 
   validateValue (out :*: _, (val, _)) = matchesBridgeOutValue out val
 
 handleTxHash ∷ Ctx → TxHashRequest → IO TxHashResponse
 handleTxHash _ctx TxHashRequest {..} = pure $ TxHashResponse {..}
-  where
-    thrHash = hasher thrTransaction
+ where
+  thrHash = hasher thrTransaction
 
 handleTxParameters ∷ Ctx → IO TxParametersResponse
-handleTxParameters _ctx = pure txParameters 
+handleTxParameters _ctx = pure txParameters
 
 -- | Check if a 'GYValue' matches the symbolic assets of an 'Output'.
 matchesBridgeOutValue ∷ KnownNat a ⇒ Output a I → GYValue → Bool

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Handlers.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Handlers.hs
@@ -5,6 +5,7 @@ module ZkFold.Cardano.Rollup.Aggregator.Handlers (
   -- * Individual Handlers
   handleHealth,
   handleSubmitTx,
+  handleTxHash,
   handleBridgeIn,
   handleSubmitL1Tx,
   handleStateInfo,
@@ -78,11 +79,16 @@ import ZkFold.Cardano.Rollup.Aggregator.Types (
   SubmitTxResponse (..),
   TxResponse (..),
   TxsByAddressResponse (..),
+  TxHashRequest (..),
+  TxHashResponse (..),
+  TxParametersResponse (..),
+  txParameters,
  )
 import ZkFold.Cardano.Rollup.Api
 import ZkFold.Data.Vector (fromVector)
 import ZkFold.Symbolic.Data.Bool (fromBool)
 import ZkFold.Symbolic.Data.FieldElement (FieldElement)
+import ZkFold.Symbolic.Data.Hash (Hashable (..))
 import ZkFold.Symbolic.Ledger.Types.Field (RollupBFInterpreter)
 import ZkFold.Symbolic.Ledger.Types.Transaction.Core (Output (..), Transaction (..))
 import ZkFold.Symbolic.Ledger.Types.Value (AssetValue (..))
@@ -92,6 +98,8 @@ aggregatorServer ∷ Ctx → ServerT AggregatorAPI IO
 aggregatorServer ctx =
   handleHealth ctx
     :<|> handleSubmitTx ctx
+    :<|> handleTxHash ctx
+    :<|> handleTxParameters ctx
     :<|> handleBridgeIn ctx
     :<|> handleSubmitL1Tx ctx
     :<|> handleStateInfo ctx
@@ -131,6 +139,14 @@ handleSubmitTx ctx SubmitTxRequest {..} = do
      in expectedAddrFe == oAddress out
 
   validateValue (out :*: _, (val, _)) = matchesBridgeOutValue out val
+
+handleTxHash ∷ Ctx → TxHashRequest → IO TxHashResponse
+handleTxHash _ctx TxHashRequest {..} = pure $ TxHashResponse {..}
+  where
+    thrHash = hasher thrTransaction
+
+handleTxParameters ∷ Ctx → IO TxParametersResponse
+handleTxParameters _ctx = pure txParameters 
 
 -- | Check if a 'GYValue' matches the symbolic assets of an 'Output'.
 matchesBridgeOutValue ∷ KnownNat a ⇒ Output a I → GYValue → Bool

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Options.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Options.hs
@@ -9,6 +9,7 @@ module ZkFold.Cardano.Rollup.Aggregator.Options (
 ) where
 
 import Options.Applicative
+
 import ZkFold.Cardano.Rollup.Aggregator.Run (runBatcher, runServer)
 
 data Command = Serve ServeCommand | Batch BatchCommand

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Persistence.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Persistence.hs
@@ -31,10 +31,11 @@ import Database.SQLite.Simple
 import Deriving.Aeson
 import GHC.Natural (Natural)
 import GeniusYield.Types (GYAddress, LowerFirst)
-import ZkFold.Cardano.Rollup.Aggregator.Types
 import ZkFold.Data.MerkleTree (Leaves)
 import ZkFold.Symbolic.Data.Hash (hHash)
 import ZkFold.Symbolic.Ledger.Types
+
+import ZkFold.Cardano.Rollup.Aggregator.Types
 
 -- | State persisted to the SQLite database across restarts.
 data PersistedState = PersistedState
@@ -330,11 +331,9 @@ loadState dbPath = withConn dbPath $ \conn → do
     query_ conn "SELECT ledger_state, utxo_preimage FROM ledger_state WHERE id = 1"
   case rows of
     [(stText, utxoText)] →
-      case
-        ( eitherDecodeStrict (encodeUtf8 stText)
-        , eitherDecodeStrict (encodeUtf8 utxoText)
-        )
-        of
-          (Right st, Right utxo) → return (Just (PersistedState st utxo))
-          _ → return Nothing
+      case ( eitherDecodeStrict (encodeUtf8 stText)
+           , eitherDecodeStrict (encodeUtf8 utxoText)
+           ) of
+        (Right st, Right utxo) → return (Just (PersistedState st utxo))
+        _ → return Nothing
     _ → return Nothing

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Run.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Run.hs
@@ -20,6 +20,13 @@ import Servant
 import Servant.Server.Experimental.Auth (AuthHandler)
 import Servant.Server.Internal.ServerError (responseServerError)
 import System.TimeManager (TimeoutThread (..))
+import ZkFold.Cardano.Rollup.Constants (zkRollupBuildInfo)
+import ZkFold.Cardano.Rollup.Types (
+  ZKInitializedRollupBuildInfo (..),
+  ZKRollupBuildInfo (..),
+  ZKRollupStakeValConfig (..),
+ )
+
 import ZkFold.Cardano.Rollup.Aggregator.Api
 import ZkFold.Cardano.Rollup.Aggregator.Auth
 import ZkFold.Cardano.Rollup.Aggregator.Batcher (initBatcherState, startBatcher)
@@ -31,12 +38,6 @@ import ZkFold.Cardano.Rollup.Aggregator.Persistence (initDb)
 import ZkFold.Cardano.Rollup.Aggregator.RequestLoggerMiddleware (gcpReqLogger)
 import ZkFold.Cardano.Rollup.Aggregator.SwaggerUI (swaggerUIHtml)
 import ZkFold.Cardano.Rollup.Aggregator.Utils
-import ZkFold.Cardano.Rollup.Constants (zkRollupBuildInfo)
-import ZkFold.Cardano.Rollup.Types (
-  ZKInitializedRollupBuildInfo (..),
-  ZKRollupBuildInfo (..),
-  ZKRollupStakeValConfig (..),
- )
 
 -- | Build a 'Ctx' from configuration and pass it to a continuation.
 withCtx ∷ Maybe FilePath → (ServerConfig → Ctx → IO ()) → IO ()

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Types.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Types.hs
@@ -15,6 +15,10 @@ module ZkFold.Cardano.Rollup.Aggregator.Types (
   -- * API Types
   SubmitTxRequest (..),
   SubmitTxResponse (..),
+  TxHashRequest (..),
+  TxHashResponse (..),
+  TxParametersResponse (..),
+  txParameters,
   BridgeInRequest (..),
   BridgeInResponse (..),
   SubmitL1TxRequest (..),
@@ -49,6 +53,7 @@ import GHC.TypeLits (Symbol)
 import GeniusYield.Swagger.Utils (dropSymbolAndCamelToSnake)
 import GeniusYield.Types (GYAddress, GYAddressBech32, GYTx, GYTxId, GYTxWitness, GYValue, LowerFirst)
 import GeniusYield.Types.OpenApi ()
+import ZkFold.Algebra.Number (Natural, value)
 import ZkFold.Cardano.Rollup.Aggregator.Orphans ()
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Symbolic.Data.FieldElement (FieldElement)
@@ -84,7 +89,7 @@ data QueuedTx = QueuedTx
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix "qt", LowerFirst]] QueuedTx
+    via CustomJSON '[FieldLabelModifier '[StripPrefix "qt", LowerFirst, CamelToSnake]] QueuedTx
 
 instance ToSchema QueuedTx where
   declareNamedSchema _ = return $ NamedSchema (Just "QueuedTx") mempty
@@ -100,7 +105,7 @@ data SubmitTxRequest = SubmitTxRequest
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitTxReqPrefix, CamelToSnake]] SubmitTxRequest
+    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitTxReqPrefix, LowerFirst, CamelToSnake]] SubmitTxRequest
 
 instance ToSchema SubmitTxRequest where
   declareNamedSchema proxy = do
@@ -124,7 +129,7 @@ data SubmitTxResponse = SubmitTxResponse
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitTxResPrefix, CamelToSnake]] SubmitTxResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitTxResPrefix, LowerFirst, CamelToSnake]] SubmitTxResponse
 
 instance ToSchema SubmitTxResponse where
   declareNamedSchema proxy = do
@@ -138,6 +143,85 @@ instance ToSchema SubmitTxResponse where
       schema
         & OpenApi.schema . OpenApi.description ?~ "Response to the L2 transaction submission"
 
+
+type TxHashReqPrefix ∷ Symbol
+type TxHashReqPrefix = "thr"
+
+newtype TxHashRequest = TxHashRequest
+  { thrTransaction ∷ Tx
+  }
+  deriving stock Generic
+  deriving
+    (FromJSON, ToJSON)
+    via CustomJSON '[FieldLabelModifier '[StripPrefix TxHashReqPrefix, LowerFirst, CamelToSnake]] TxHashRequest
+
+instance ToSchema TxHashRequest where
+  declareNamedSchema proxy = do
+    schema ←
+      OpenApi.genericDeclareNamedSchema
+        OpenApi.defaultSchemaOptions
+          { OpenApi.fieldLabelModifier = dropSymbolAndCamelToSnake @TxHashReqPrefix
+          }
+        proxy
+    return $
+      schema
+        & OpenApi.schema . OpenApi.description ?~ "Calculate the hash of an L2 transaction"
+
+type TxHashResPrefix ∷ Symbol
+type TxHashResPrefix = "thr"
+
+newtype TxHashResponse = TxHashResponse
+  { thrHash ∷ FieldElement RollupBFInterpreter 
+  }
+  deriving stock Generic
+  deriving
+    (FromJSON, ToJSON)
+    via CustomJSON '[FieldLabelModifier '[StripPrefix TxHashResPrefix, LowerFirst, CamelToSnake]] TxHashResponse
+
+instance ToSchema TxHashResponse where
+  declareNamedSchema proxy = do
+    schema ←
+      OpenApi.genericDeclareNamedSchema
+        OpenApi.defaultSchemaOptions
+          { OpenApi.fieldLabelModifier = dropSymbolAndCamelToSnake @TxHashResPrefix
+          }
+        proxy
+    return $
+      schema
+        & OpenApi.schema . OpenApi.description ?~ "The hash of on L2 transaction"
+
+type TxParametersPrefix ∷ Symbol
+type TxParametersPrefix = "tpr"
+
+data TxParametersResponse = TxParametersResponse
+  { tprInputs ∷ !Natural 
+  , tprOutputs ∷ !Natural 
+  , tprAssets ∷ !Natural 
+  }
+  deriving stock Generic
+  deriving
+    (FromJSON, ToJSON)
+    via CustomJSON '[FieldLabelModifier '[StripPrefix TxParametersPrefix, LowerFirst, CamelToSnake]] TxParametersResponse
+
+instance ToSchema TxParametersResponse where
+  declareNamedSchema proxy = do
+    schema ←
+      OpenApi.genericDeclareNamedSchema
+        OpenApi.defaultSchemaOptions
+          { OpenApi.fieldLabelModifier = dropSymbolAndCamelToSnake @TxHashResPrefix
+          }
+        proxy
+    return $
+      schema
+        & OpenApi.schema . OpenApi.description ?~ "The hash of on L2 transaction"
+
+txParameters :: TxParametersResponse
+txParameters = TxParametersResponse {..}
+  where
+    tprInputs = value @Ixs
+    tprOutputs = value @Oxs
+    tprAssets = value @A
+
 type BridgeInReqPrefix ∷ Symbol
 type BridgeInReqPrefix = "bir"
 
@@ -150,7 +234,7 @@ data BridgeInRequest = BridgeInRequest
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix BridgeInReqPrefix, CamelToSnake]] BridgeInRequest
+    via CustomJSON '[FieldLabelModifier '[StripPrefix BridgeInReqPrefix, LowerFirst, CamelToSnake]] BridgeInRequest
 
 instance ToSchema BridgeInRequest where
   declareNamedSchema proxy = do
@@ -173,7 +257,7 @@ newtype BridgeInResponse = BridgeInResponse
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix BridgeInResPrefix, CamelToSnake]] BridgeInResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix BridgeInResPrefix, LowerFirst, CamelToSnake]] BridgeInResponse
 
 instance ToSchema BridgeInResponse where
   declareNamedSchema proxy = do
@@ -197,7 +281,7 @@ data SubmitL1TxRequest = SubmitL1TxRequest
   deriving stock Generic
   deriving
     FromJSON
-    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitL1TxReqPrefix, CamelToSnake]] SubmitL1TxRequest
+    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitL1TxReqPrefix, LowerFirst, CamelToSnake]] SubmitL1TxRequest
 
 instance ToSchema SubmitL1TxRequest where
   declareNamedSchema proxy = do
@@ -220,7 +304,7 @@ newtype SubmitL1TxResponse = SubmitL1TxResponse
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitL1TxResPrefix, CamelToSnake]] SubmitL1TxResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitL1TxResPrefix, LowerFirst, CamelToSnake]] SubmitL1TxResponse
 
 instance ToSchema SubmitL1TxResponse where
   declareNamedSchema proxy = do
@@ -243,7 +327,7 @@ newtype QueryL2UtxosResponse = QueryL2UtxosResponse
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix QueryL2UtxosResPrefix, CamelToSnake]] QueryL2UtxosResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix QueryL2UtxosResPrefix, LowerFirst, CamelToSnake]] QueryL2UtxosResponse
 
 instance ToSchema QueryL2UtxosResponse where
   declareNamedSchema proxy = do

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Types.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Types.hs
@@ -240,7 +240,6 @@ type TxParametersPrefix = "tpr"
 
 data TxParametersResponse = TxParametersResponse
   { tprInputs ∷ !Natural
-  , tprOutputs ∷ !Natural
   , tprAssets ∷ !Natural
   }
   deriving stock Generic
@@ -263,8 +262,7 @@ instance ToSchema TxParametersResponse where
 txParameters ∷ TxParametersResponse
 txParameters = TxParametersResponse {..}
  where
-  tprInputs = value @Ixs
-  tprOutputs = value @Oxs
+  tprInputs = value @N
   tprAssets = value @A
 
 type BridgeInReqPrefix ∷ Symbol

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Types.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Types.hs
@@ -53,7 +53,7 @@ import Deriving.Aeson
 import GHC.Generics ((:*:) (..), (:.:) (..))
 import GHC.TypeLits (Symbol)
 import GeniusYield.Swagger.Utils (dropSymbolAndCamelToSnake)
-import GeniusYield.Types (GYAddress, GYAddressBech32, GYTx, GYTxId, GYTxWitness, GYValue)
+import GeniusYield.Types (GYAddress, GYAddressBech32, GYTx, GYTxId, GYTxWitness, GYValue, LowerFirst)
 import GeniusYield.Types.OpenApi ()
 import ZkFold.Algebra.Number (Natural, value)
 import ZkFold.Data.Vector (Vector)
@@ -415,7 +415,7 @@ data TxStatus = TxPending | TxProcessing | TxBatched
   deriving stock (Eq, Generic, Show)
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[ConstructorTagModifier '[StripPrefix "Tx"]] TxStatus
+    via CustomJSON '[ConstructorTagModifier '[StripPrefix "Tx", LowerFirst]] TxStatus
 
 instance ToSchema TxStatus where
   declareNamedSchema proxy =

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Types.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Types.hs
@@ -25,6 +25,8 @@ module ZkFold.Cardano.Rollup.Aggregator.Types (
   SubmitL1TxResponse (..),
   QueryL2UtxosResponse (..),
   StateInfoResponse (..),
+  ConvertAddressRequest (..),
+  ConvertAddressResponse (..),
 
   -- * Indexing Types
   TxStatus (..),
@@ -51,15 +53,16 @@ import Deriving.Aeson
 import GHC.Generics ((:*:) (..), (:.:) (..))
 import GHC.TypeLits (Symbol)
 import GeniusYield.Swagger.Utils (dropSymbolAndCamelToSnake)
-import GeniusYield.Types (GYAddress, GYAddressBech32, GYTx, GYTxId, GYTxWitness, GYValue, LowerFirst)
+import GeniusYield.Types (GYAddress, GYAddressBech32, GYTx, GYTxId, GYTxWitness, GYValue)
 import GeniusYield.Types.OpenApi ()
 import ZkFold.Algebra.Number (Natural, value)
-import ZkFold.Cardano.Rollup.Aggregator.Orphans ()
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Symbolic.Data.FieldElement (FieldElement)
 import ZkFold.Symbolic.Ledger.Types
 import ZkFold.Symbolic.Ledger.Types.Field (RollupBFInterpreter)
 import ZkFold.Symbolic.Ledger.Types.Orphans ()
+
+import ZkFold.Cardano.Rollup.Aggregator.Orphans ()
 
 type I = RollupBFInterpreter
 
@@ -89,10 +92,53 @@ data QueuedTx = QueuedTx
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix "qt", LowerFirst, CamelToSnake]] QueuedTx
+    via CustomJSON '[FieldLabelModifier '[StripPrefix "qt", CamelToSnake]] QueuedTx
 
 instance ToSchema QueuedTx where
   declareNamedSchema _ = return $ NamedSchema (Just "QueuedTx") mempty
+
+type ConvertAddressPrefix ∷ Symbol
+type ConvertAddressPrefix = "car"
+
+newtype ConvertAddressRequest = ConvertAddressRequest
+  { carAddress ∷ GYAddressBech32
+  }
+  deriving stock Generic
+  deriving
+    (FromJSON, ToJSON)
+    via CustomJSON '[FieldLabelModifier '[StripPrefix ConvertAddressPrefix, CamelToSnake]] ConvertAddressRequest
+
+instance ToSchema ConvertAddressRequest where
+  declareNamedSchema proxy = do
+    schema ←
+      OpenApi.genericDeclareNamedSchema
+        OpenApi.defaultSchemaOptions
+          { OpenApi.fieldLabelModifier = dropSymbolAndCamelToSnake @ConvertAddressPrefix
+          }
+        proxy
+    return $
+      schema
+        & OpenApi.schema . OpenApi.description ?~ "Request parameters to convert Cardano address into a dummy L2 address"
+
+newtype ConvertAddressResponse = ConvertAddressResponse
+  { carL2Address ∷ FieldElement RollupBFInterpreter
+  }
+  deriving stock Generic
+  deriving
+    (FromJSON, ToJSON)
+    via CustomJSON '[FieldLabelModifier '[StripPrefix ConvertAddressPrefix, CamelToSnake]] ConvertAddressResponse
+
+instance ToSchema ConvertAddressResponse where
+  declareNamedSchema proxy = do
+    schema ←
+      OpenApi.genericDeclareNamedSchema
+        OpenApi.defaultSchemaOptions
+          { OpenApi.fieldLabelModifier = dropSymbolAndCamelToSnake @ConvertAddressPrefix
+          }
+        proxy
+    return $
+      schema
+        & OpenApi.schema . OpenApi.description ?~ "Dummy L2 address corresponding to a Cardano address"
 
 type SubmitTxReqPrefix ∷ Symbol
 type SubmitTxReqPrefix = "str"
@@ -105,7 +151,7 @@ data SubmitTxRequest = SubmitTxRequest
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitTxReqPrefix, LowerFirst, CamelToSnake]] SubmitTxRequest
+    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitTxReqPrefix, CamelToSnake]] SubmitTxRequest
 
 instance ToSchema SubmitTxRequest where
   declareNamedSchema proxy = do
@@ -129,7 +175,7 @@ data SubmitTxResponse = SubmitTxResponse
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitTxResPrefix, LowerFirst, CamelToSnake]] SubmitTxResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitTxResPrefix, CamelToSnake]] SubmitTxResponse
 
 instance ToSchema SubmitTxResponse where
   declareNamedSchema proxy = do
@@ -143,7 +189,6 @@ instance ToSchema SubmitTxResponse where
       schema
         & OpenApi.schema . OpenApi.description ?~ "Response to the L2 transaction submission"
 
-
 type TxHashReqPrefix ∷ Symbol
 type TxHashReqPrefix = "thr"
 
@@ -153,7 +198,7 @@ newtype TxHashRequest = TxHashRequest
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix TxHashReqPrefix, LowerFirst, CamelToSnake]] TxHashRequest
+    via CustomJSON '[FieldLabelModifier '[StripPrefix TxHashReqPrefix, CamelToSnake]] TxHashRequest
 
 instance ToSchema TxHashRequest where
   declareNamedSchema proxy = do
@@ -171,12 +216,12 @@ type TxHashResPrefix ∷ Symbol
 type TxHashResPrefix = "thr"
 
 newtype TxHashResponse = TxHashResponse
-  { thrHash ∷ FieldElement RollupBFInterpreter 
+  { thrHash ∷ FieldElement RollupBFInterpreter
   }
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix TxHashResPrefix, LowerFirst, CamelToSnake]] TxHashResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix TxHashResPrefix, CamelToSnake]] TxHashResponse
 
 instance ToSchema TxHashResponse where
   declareNamedSchema proxy = do
@@ -194,14 +239,14 @@ type TxParametersPrefix ∷ Symbol
 type TxParametersPrefix = "tpr"
 
 data TxParametersResponse = TxParametersResponse
-  { tprInputs ∷ !Natural 
-  , tprOutputs ∷ !Natural 
-  , tprAssets ∷ !Natural 
+  { tprInputs ∷ !Natural
+  , tprOutputs ∷ !Natural
+  , tprAssets ∷ !Natural
   }
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix TxParametersPrefix, LowerFirst, CamelToSnake]] TxParametersResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix TxParametersPrefix, CamelToSnake]] TxParametersResponse
 
 instance ToSchema TxParametersResponse where
   declareNamedSchema proxy = do
@@ -215,12 +260,12 @@ instance ToSchema TxParametersResponse where
       schema
         & OpenApi.schema . OpenApi.description ?~ "The hash of on L2 transaction"
 
-txParameters :: TxParametersResponse
+txParameters ∷ TxParametersResponse
 txParameters = TxParametersResponse {..}
-  where
-    tprInputs = value @Ixs
-    tprOutputs = value @Oxs
-    tprAssets = value @A
+ where
+  tprInputs = value @Ixs
+  tprOutputs = value @Oxs
+  tprAssets = value @A
 
 type BridgeInReqPrefix ∷ Symbol
 type BridgeInReqPrefix = "bir"
@@ -234,7 +279,7 @@ data BridgeInRequest = BridgeInRequest
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix BridgeInReqPrefix, LowerFirst, CamelToSnake]] BridgeInRequest
+    via CustomJSON '[FieldLabelModifier '[StripPrefix BridgeInReqPrefix, CamelToSnake]] BridgeInRequest
 
 instance ToSchema BridgeInRequest where
   declareNamedSchema proxy = do
@@ -257,7 +302,7 @@ newtype BridgeInResponse = BridgeInResponse
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix BridgeInResPrefix, LowerFirst, CamelToSnake]] BridgeInResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix BridgeInResPrefix, CamelToSnake]] BridgeInResponse
 
 instance ToSchema BridgeInResponse where
   declareNamedSchema proxy = do
@@ -281,7 +326,7 @@ data SubmitL1TxRequest = SubmitL1TxRequest
   deriving stock Generic
   deriving
     FromJSON
-    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitL1TxReqPrefix, LowerFirst, CamelToSnake]] SubmitL1TxRequest
+    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitL1TxReqPrefix, CamelToSnake]] SubmitL1TxRequest
 
 instance ToSchema SubmitL1TxRequest where
   declareNamedSchema proxy = do
@@ -304,7 +349,7 @@ newtype SubmitL1TxResponse = SubmitL1TxResponse
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitL1TxResPrefix, LowerFirst, CamelToSnake]] SubmitL1TxResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix SubmitL1TxResPrefix, CamelToSnake]] SubmitL1TxResponse
 
 instance ToSchema SubmitL1TxResponse where
   declareNamedSchema proxy = do
@@ -327,7 +372,7 @@ newtype QueryL2UtxosResponse = QueryL2UtxosResponse
   deriving stock Generic
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[FieldLabelModifier '[StripPrefix QueryL2UtxosResPrefix, LowerFirst, CamelToSnake]] QueryL2UtxosResponse
+    via CustomJSON '[FieldLabelModifier '[StripPrefix QueryL2UtxosResPrefix, CamelToSnake]] QueryL2UtxosResponse
 
 instance ToSchema QueryL2UtxosResponse where
   declareNamedSchema proxy = do
@@ -369,10 +414,10 @@ instance ToSchema StateInfoResponse where
 -- ---------------------------------------------------------------------------
 
 data TxStatus = TxPending | TxProcessing | TxBatched
-  deriving stock (Eq, Show, Generic)
+  deriving stock (Eq, Generic, Show)
   deriving
     (FromJSON, ToJSON)
-    via CustomJSON '[ConstructorTagModifier '[StripPrefix "Tx", LowerFirst]] TxStatus
+    via CustomJSON '[ConstructorTagModifier '[StripPrefix "Tx"]] TxStatus
 
 instance ToSchema TxStatus where
   declareNamedSchema proxy =

--- a/web/openapi/api.yaml
+++ b/web/openapi/api.yaml
@@ -289,6 +289,42 @@ components:
       - inputs
       - outputs
       type: object
+    TxHashRequest:
+      description: Calculate the hash of an L2 transaction
+      properties:
+        transaction:
+          $ref: '#/components/schemas/Transaction_2_2_2_(Interpreter_*_(Zp_52435875175126190479447740508185965837690552500527637822603658699938581184513))'
+      required:
+      - transaction
+      type: object
+    TxHashResponse:
+      description: The hash of on L2 transaction
+      properties:
+        hash:
+          type: integer
+      required:
+      - hash
+      type: object
+    TxParametersResponse:
+      description: The hash of on L2 transaction
+      properties:
+        assets:
+          exclusiveMinimum: false
+          minimum: 0
+          type: integer
+        inputs:
+          exclusiveMinimum: false
+          minimum: 0
+          type: integer
+        outputs:
+          exclusiveMinimum: false
+          minimum: 0
+          type: integer
+      required:
+      - inputs
+      - outputs
+      - assets
+      type: object
     TxRecord:
       description: A transaction record with status information
       properties:
@@ -553,6 +589,35 @@ paths:
       summary: Submit L2 transaction
       tags:
       - Transactions
+  /v0/tx/hash:
+    post:
+      requestBody:
+        content:
+          application/json;charset=utf-8:
+            schema:
+              $ref: '#/components/schemas/TxHashRequest'
+      responses:
+        '200':
+          content:
+            application/json;charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/TxHashResponse'
+          description: ''
+        '400':
+          description: Invalid `body`
+      tags:
+      - Transactions
+  /v0/tx/parameters:
+    get:
+      responses:
+        '200':
+          content:
+            application/json;charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/TxParametersResponse'
+          description: ''
+      tags:
+      - Transactions
   /v0/tx/{hash}:
     get:
       description: Retrieve a single queued transaction by its hash (the JSON-encoded
@@ -654,6 +719,10 @@ tags:
 - description: Endpoint to check if the server is healthy.
   name: Settings
 - description: Submit a single L2 transaction for batching.
+  name: Transactions
+- description: Calculate hash of an L2 transaction.
+  name: Transactions
+- description: Obtain current transaction parameters.
   name: Transactions
 - description: Bridge operations.
   name: Bridge

--- a/web/openapi/api.yaml
+++ b/web/openapi/api.yaml
@@ -309,7 +309,7 @@ components:
       description: Calculate the hash of an L2 transaction
       properties:
         transaction:
-          $ref: '#/components/schemas/Transaction_2_2_2_(Interpreter_*_(Zp_52435875175126190479447740508185965837690552500527637822603658699938581184513))'
+          $ref: '#/components/schemas/Transaction_2_2_(Interpreter_*_(Zp_52435875175126190479447740508185965837690552500527637822603658699938581184513))'
       required:
       - transaction
       type: object
@@ -332,13 +332,8 @@ components:
           exclusiveMinimum: false
           minimum: 0
           type: integer
-        outputs:
-          exclusiveMinimum: false
-          minimum: 0
-          type: integer
       required:
       - inputs
-      - outputs
       - assets
       type: object
     TxRecord:

--- a/web/openapi/api.yaml
+++ b/web/openapi/api.yaml
@@ -119,6 +119,22 @@ components:
       required:
       - entries
       type: object
+    ConvertAddressRequest:
+      description: Request parameters to convert Cardano address into a dummy L2 address
+      properties:
+        address:
+          $ref: '#/components/schemas/GYAddressBech32'
+      required:
+      - address
+      type: object
+    ConvertAddressResponse:
+      description: Dummy L2 address corresponding to a Cardano address
+      properties:
+        l2_address:
+          type: integer
+      required:
+      - l2_address
+      type: object
     GYAddressBech32:
       description: An address, serialised as Bech32.
       example: addr_test1qrsuhwqdhz0zjgnf46unas27h93amfghddnff8lpc2n28rgmjv8f77ka0zshfgssqr5cnl64zdnde5f8q2xt923e7ctqu49mg5
@@ -532,6 +548,29 @@ paths:
       summary: Health check
       tags:
       - Settings
+  /v0/l1/address/convert:
+    post:
+      description: In bridge-out transactions, the L2 address in the transaction outputs
+        must be obtained from an L1 Cardano address using this endpoint. The resulting
+        L2 address will only be a dummy address and must not be used anywhere other
+        than bridge-out transactions.
+      requestBody:
+        content:
+          application/json;charset=utf-8:
+            schema:
+              $ref: '#/components/schemas/ConvertAddressRequest'
+      responses:
+        '200':
+          content:
+            application/json;charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/ConvertAddressResponse'
+          description: ''
+        '400':
+          description: Invalid `body`
+      summary: Convert Cardano address into a dummy L2 address
+      tags:
+      - Address
   /v0/l1/tx/submit:
     post:
       description: Attach a witness to a previously built L1 transaction (e.g. a bridge-in)
@@ -605,10 +644,13 @@ paths:
           description: ''
         '400':
           description: Invalid `body`
+      summary: Get hash of an L2 transaction
       tags:
       - Transactions
   /v0/tx/parameters:
     get:
+      description: Obtain the supported number of inputs, outputs and assets in L2
+        trasactions.
       responses:
         '200':
           content:
@@ -616,6 +658,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TxParametersResponse'
           description: ''
+      summary: Obtain transaction parameters
       tags:
       - Transactions
   /v0/tx/{hash}:
@@ -718,6 +761,8 @@ paths:
 tags:
 - description: Endpoint to check if the server is healthy.
   name: Settings
+- description: Convert L1 address to a dummy L2 address.
+  name: Address
 - description: Submit a single L2 transaction for batching.
   name: Transactions
 - description: Calculate hash of an L2 transaction.

--- a/web/openapi/api.yaml
+++ b/web/openapi/api.yaml
@@ -563,7 +563,7 @@ paths:
           description: ''
         '400':
           description: Invalid `body`
-      summary: Convert Cardano address into a dummy L2 address
+      summary: Obtain Symbolic representation of a Cardano address
       tags:
       - Address
   /v0/l1/tx/submit:


### PR DESCRIPTION
Endpoints to obtain the hash of a transaction and to obtain the type-level parameters of transactions (number of inputs, outputs and assets).
Also, fixes field names to be snake_case as suggested by Swagger