### PR TITLE
Restore Maestro light mode for aggregator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,11 +75,13 @@ batchConfig:
 apiKey: SERVER_API_KEY
 # File path where to persist rollup-state. When starting from initial state, this file can be empty.
 dbPath: rollup.db
-# Access to socket path of running cardano node for chain sync event listener to track the accumulating onchain L2 state.
-nodeSocketPath: path/to/node.socket
-chainSyncStartPoint:
-  slot: 120542468
-  blockHash: 5c55360e637428f54e7fa891cd1fb29b094599090a0f7ffb09492cc033ab39b0
+# Use light mode for a Maestro-only demo without a local cardano-node socket.
+syncMode: light
+# For full node sync, use syncMode: node and configure the node socket:
+# nodeSocketPath: path/to/node.socket
+# chainSyncStartPoint:
+#   slot: 120542468
+#   blockHash: 5c55360e637428f54e7fa891cd1fb29b094599090a0f7ffb09492cc033ab39b0
 maxBridgeIn: 1
 maxBridgeOut: 1
 maxOutputAssets: 2

--- a/rollup-aggregator-server/rollup-aggregator-server.cabal
+++ b/rollup-aggregator-server/rollup-aggregator-server.cabal
@@ -38,7 +38,6 @@ common common
     -Wincomplete-uni-patterns
     -Wunused-packages
     -threaded
-    "-with-rtsopts=-A128M -AL256m -qb0 -N"
 
 library
   import: common
@@ -119,6 +118,7 @@ test-suite rollup-aggregator-server-tests
     -with-rtsopts=-I0
 
   other-modules:
+    ZkFold.Cardano.Rollup.Aggregator.Test.Config
     ZkFold.Cardano.Rollup.Aggregator.Test.EndToEnd
     ZkFold.Cardano.Rollup.Aggregator.Test.Validation
 
@@ -144,6 +144,8 @@ executable rollup-aggregator-server
   import: common
   main-is: Main.hs
   hs-source-dirs: app
+  ghc-options:
+    "-with-rtsopts=-A128M -AL256m -qb0 -N"
   build-depends:
     base,
     optparse-applicative,

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Batcher.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Batcher.hs
@@ -4,6 +4,7 @@ module ZkFold.Cardano.Rollup.Aggregator.Batcher (
   startBatcher,
   enqueueTx,
   processBatch,
+  processBatchLight,
   initialState,
   queryBridgeIns,
   nullQueuedTx,
@@ -69,7 +70,7 @@ import System.Timeout (timeout)
 import ZkFold.Algebra.Class (FromConstant (..), zero)
 import ZkFold.Algebra.EllipticCurve.BLS12_381 (BLS12_381_G1_JacobianPoint)
 import ZkFold.Algebra.EllipticCurve.Class (TwistedEdwards (..))
-import ZkFold.Cardano.Rollup.Aggregator.Config (BatchConfig (..))
+import ZkFold.Cardano.Rollup.Aggregator.Config (BatchConfig (..), SyncMode (..))
 import ZkFold.Cardano.Rollup.Aggregator.Ctx (Ctx (..), runQuery)
 import ZkFold.Cardano.Rollup.Aggregator.Persistence (
   PersistedState (..),
@@ -85,6 +86,7 @@ import ZkFold.Cardano.Rollup.Aggregator.Persistence (
   revertProcessingTxsDb,
   revertTxsDb,
   saveBatchResultDb,
+  saveLightBatchResultDb,
   savePreimagesDb,
   seedPreimageDbFromOldState,
  )
@@ -117,17 +119,17 @@ import ZkFold.Symbolic.Ledger.Utils (unsafeToVector')
 
 -- | In-process mutable state and cryptographic material for the batcher.
 --
--- ChainSync is the single source of truth for state and Merkle tree leaf hashes.
--- The Batcher reads state from ChainSync's TVars and constructs the preimage
--- from the @utxo_preimages@ DB table. The tree is derived from the preimage
--- (guaranteed consistent after the @search@ fix in symbolic-base).
+-- In node sync mode ChainSync is the single source of truth for state and
+-- Merkle tree leaf hashes. In light sync mode the Batcher updates the same
+-- TVars after its own L1 submission is confirmed. The tree is derived from the
+-- preimage (guaranteed consistent after the @search@ fix in symbolic-base).
 data BatcherState = BatcherState
   { bsLedgerStateVar ∷ !(TVar (State I))
-  -- ^ Rollup state. Written by ChainSync only.
+  -- ^ Rollup state. Written by ChainSync in node mode or the Batcher in light mode.
   , bsLeafHashesVar ∷ !(TVar (Leaves Ud (FieldElement I)))
-  -- ^ Merkle tree leaf hashes. Written by ChainSync only.
+  -- ^ Merkle tree leaf hashes. Written by ChainSync in node mode or the Batcher in light mode.
   , bsMerkleTreeVar ∷ !(TVar (SymMerkle.MerkleTree Ud I))
-  -- ^ Merkle tree derived from leaf hashes. Written by ChainSync only.
+  -- ^ Merkle tree derived from leaf hashes. Written by ChainSync in node mode or the Batcher in light mode.
   , bsTrustedSetup ∷ !(TrustedSetup (G + 6))
   , bsLedgerCircuit ∷ !(LedgerCircuit Bi Bo Ud A S N TxCount)
   , bsProverSecret ∷ !(PlonkupProverSecret BLS12_381_G1_JacobianPoint)
@@ -350,62 +352,62 @@ nullQueuedTx =
 -- and processes a batch when either:
 -- * enough real transactions are queued (≥ bcBatchTransactions), or
 -- * there are pending bridge-ins on L1 (remaining slots are padded with null txs).
-startBatcher ∷ Ctx → BatcherState → IO ()
-startBatcher ctx@Ctx {..} bs = do
+startBatcher ∷ SyncMode → Ctx → BatcherState → IO ()
+startBatcher syncMode ctx@Ctx {..} bs = do
   -- Crash recovery: revert any txs that were left in 'processing' state from a
-  -- prior run. Without this they would be stuck until ChainSync detects a state
-  -- change, and in the worst case (L1 confirmed but DB not updated) they could
-  -- be silently orphaned.
+  -- prior run. Without this they would be stuck until the next state change, and
+  -- in the worst case (L1 confirmed but DB not updated) they could be silently
+  -- orphaned.
   revertProcessingTxsDb ctxDbPath
-  -- Track ChainSync's chain length to detect external updates and for waitForChainSync.
-  lastChainSyncLenRef ← readTVarIO (bsLedgerStateVar bs) >>= newTVarIO . feToInteger . sLength
+  -- Track state length to detect ChainSync updates in node mode and to avoid
+  -- duplicate wait checks after local commits in light mode.
+  lastStateLenRef ← readTVarIO (bsLedgerStateVar bs) >>= newTVarIO . feToInteger . sLength
   chainSyncWarnedRef ← newIORef False
   forever $ do
     let delayMicros = fromIntegral (bcBatchIntervalSeconds ctxBatchConfig) * 1_000_000
     threadDelay delayMicros
-    -- Check ChainSync liveness: warn if no block processed in 5 minutes.
-    now ← getCurrentTime
-    lastAlive ← readTVarIO (bsChainSyncAliveVar bs)
-    let staleSecs = realToFrac (diffUTCTime now lastAlive) ∷ Double
-    alreadyWarned ← readIORef chainSyncWarnedRef
-    if staleSecs > 300
-      then
-        unless alreadyWarned $ do
-          gyLogWarning ctxProviders mempty $
-            "ChainSync appears stuck: no block processed in " <> show (round staleSecs ∷ Int) <> "s"
-          writeIORef chainSyncWarnedRef True
-      else
-        when alreadyWarned $ do
-          gyLogInfo ctxProviders mempty "ChainSync recovered, processing blocks again"
-          writeIORef chainSyncWarnedRef False
-    -- Detect state changes from ChainSync (external updates or rollbacks).
-    -- bsLedgerStateVar is written ONLY by ChainSync, so changes indicate
-    -- on-chain state updates.
-    currentLen ← feToInteger . sLength <$> readTVarIO (bsLedgerStateVar bs)
-    prevLen ← readTVarIO lastChainSyncLenRef
-    when (currentLen /= prevLen) $ do
-      gyLogInfo ctxProviders mempty $
-        "ChainSync state changed (len "
-          <> show prevLen
-          <> " → "
-          <> show currentLen
-          <> "), revalidating pending txs"
-      revertProcessingTxsDb ctxDbPath
-      revalidatePendingTxs ctx bs
-      atomically $ writeTVar lastChainSyncLenRef currentLen
-    -- Guard: verify ChainSync's in-memory state matches the on-chain rollup state
-    -- before generating any ZK proof. If chain sync is still replaying history (e.g.
-    -- fresh start from genesis with no persisted checkpoint), the UTxO tree roots will
-    -- diverge and any proof built from the stale local state will be rejected on-chain.
+    when (syncMode == SyncNode) $ do
+      -- Check ChainSync liveness: warn if no block processed in 5 minutes.
+      now ← getCurrentTime
+      lastAlive ← readTVarIO (bsChainSyncAliveVar bs)
+      let staleSecs = realToFrac (diffUTCTime now lastAlive) ∷ Double
+      alreadyWarned ← readIORef chainSyncWarnedRef
+      if staleSecs > 300
+        then
+          unless alreadyWarned $ do
+            gyLogWarning ctxProviders mempty $
+              "ChainSync appears stuck: no block processed in " <> show (round staleSecs ∷ Int) <> "s"
+            writeIORef chainSyncWarnedRef True
+        else
+          when alreadyWarned $ do
+            gyLogInfo ctxProviders mempty "ChainSync recovered, processing blocks again"
+            writeIORef chainSyncWarnedRef False
+      -- Detect state changes from ChainSync (external updates or rollbacks).
+      currentLen ← feToInteger . sLength <$> readTVarIO (bsLedgerStateVar bs)
+      prevLen ← readTVarIO lastStateLenRef
+      when (currentLen /= prevLen) $ do
+        gyLogInfo ctxProviders mempty $
+          "ChainSync state changed (len "
+            <> show prevLen
+            <> " → "
+            <> show currentLen
+            <> "), revalidating pending txs"
+        revertProcessingTxsDb ctxDbPath
+        revalidatePendingTxs ctx bs
+        atomically $ writeTVar lastStateLenRef currentLen
+    -- Guard: verify the local in-memory state matches the on-chain rollup state
+    -- before generating any ZK proof. In node mode this protects against ChainSync
+    -- lag; in light mode it prevents batching after external updates or crash
+    -- windows that left the local DB stale.
     localRoot ← feToInteger . sUTxO <$> readTVarIO (bsLedgerStateVar bs)
     mOnChainRoot ← queryOnChainUTxORoot ctx
-    let chainSyncCaughtUp = case mOnChainRoot of
+    let localStateMatchesChain = case mOnChainRoot of
           Just onChainRoot → onChainRoot == localRoot
           Nothing → True -- no state UTxO yet (rollup not deployed); safe to proceed
-    if not chainSyncCaughtUp
+    if not localStateMatchesChain
       then
         gyLogWarning ctxProviders mempty $
-          "ChainSync not yet caught up to on-chain state (local root "
+          "Local rollup state does not match on-chain state (local root "
             <> show localRoot
             <> " ≠ on-chain root "
             <> show (maybe 0 id mOnChainRoot)
@@ -421,20 +423,28 @@ startBatcher ctx@Ctx {..} bs = do
             available ← dequeueAvailableTxsDb ctxDbPath (bcBatchTransactions ctxBatchConfig)
             let (ids, qtxs) = unzip available
                 padded = qtxs ++ replicate (txCount - length qtxs) nullQueuedTx
-            processBatchWithLogging ctx bs ids padded lastChainSyncLenRef
+            processBatchWithLogging syncMode ctx bs ids padded lastStateLenRef
           else do
             mQueued ← dequeueTxsDb ctxDbPath (bcBatchTransactions ctxBatchConfig)
             for_ mQueued $ \pairs →
               let (ids, qtxs) = unzip pairs
-               in processBatchWithLogging ctx bs ids qtxs lastChainSyncLenRef
+               in processBatchWithLogging syncMode ctx bs ids qtxs lastStateLenRef
 
-processBatchWithLogging ∷ Ctx → BatcherState → [Int64] → [QueuedTx] → TVar Integer → IO ()
-processBatchWithLogging ctx@Ctx {..} bs ids queued lastLenRef =
+processBatchWithLogging ∷ SyncMode → Ctx → BatcherState → [Int64] → [QueuedTx] → TVar Integer → IO ()
+processBatchWithLogging syncMode ctx@Ctx {..} bs ids queued lastLenRef =
   ( do
-      tid ← processBatch ctx bs ids queued
+      tid ← case syncMode of
+        SyncNode → processBatch ctx bs ids queued
+        SyncLight → processBatchLight ctx bs ids queued
       gyLogInfo ctxProviders mempty $ "Batch submitted: " <> show tid
-      -- Wait for ChainSync to process the block.
-      waitForChainSync ctx bs lastLenRef
+      case syncMode of
+        SyncNode →
+          -- Wait for ChainSync to process the block.
+          waitForChainSync ctx bs lastLenRef
+        SyncLight → do
+          newLen ← feToInteger . sLength <$> readTVarIO (bsLedgerStateVar bs)
+          atomically $ writeTVar lastLenRef newLen
+          gyLogInfo ctxProviders mempty "Light mode committed local state update"
   )
     `catches` [ Handler (\(err ∷ GYTxMonadException) → revert >> logException "GYTxMonadException" err)
               , Handler (\(err ∷ SubmitTxException) → revert >> logException "SubmitTxException" err)
@@ -511,9 +521,19 @@ constructPreimage providers dbPath leafHashes = do
       )
       leafHashes
 
+-- | Process a batch in node sync mode. The confirmed L1 transaction is recorded,
+-- but local state is left for ChainSync to observe and persist.
 processBatch ∷ Ctx → BatcherState → [Int64] → [QueuedTx] → IO GYTxId
-processBatch ctx@Ctx {..} BatcherState {..} ids queuedTxs = do
-  -- Read state from ChainSync's TVar, construct preimage from DB, derive tree.
+processBatch = processBatchWithMode SyncNode
+
+-- | Process a batch in light sync mode. After Maestro confirms the L1
+-- transaction, the batcher persists and publishes the new local state itself.
+processBatchLight ∷ Ctx → BatcherState → [Int64] → [QueuedTx] → IO GYTxId
+processBatchLight = processBatchWithMode SyncLight
+
+processBatchWithMode ∷ SyncMode → Ctx → BatcherState → [Int64] → [QueuedTx] → IO GYTxId
+processBatchWithMode syncMode ctx@Ctx {..} BatcherState {..} ids queuedTxs = do
+  -- Read state from the shared TVar, construct preimage from DB, derive tree.
   -- With the search fix in symbolic-base, fromLeaves(fmap(hHash.hash) preimage)
   -- produces the same tree as updateLedgerState's output.
   (prevState, prevLeafHashes) ←
@@ -529,6 +549,8 @@ processBatch ctx@Ctx {..} BatcherState {..} ids queuedTxs = do
       newState :*: witness :*: _newTree :*: preimageWrapped =
         updateLedgerState prevState prevTree prevUtxoPreimage bridgedIn batch sigMaterial
       newPreimage = unComp1 preimageWrapped
+      newLeafHashes = fmap (hHash . hash) newPreimage
+      newMerkleTree = SymMerkle.fromLeaves newLeafHashes
       lci =
         LedgerContractInput
           { lciPreviousState = prevState
@@ -577,5 +599,13 @@ processBatch ctx@Ctx {..} BatcherState {..} ids queuedTxs = do
         body ← buildTxBody skel
         signAndSubmitConfirmed body
   -- Atomically: store preimages + record batch + mark txs as batched.
-  saveBatchResultDb ctxDbPath newEntries ids (Text.pack (show submittedTxId))
+  case syncMode of
+    SyncNode →
+      saveBatchResultDb ctxDbPath newEntries ids (Text.pack (show submittedTxId))
+    SyncLight → do
+      saveLightBatchResultDb ctxDbPath newState newLeafHashes newEntries ids (Text.pack (show submittedTxId))
+      atomically $ do
+        writeTVar bsLedgerStateVar newState
+        writeTVar bsLeafHashesVar newLeafHashes
+        writeTVar bsMerkleTreeVar newMerkleTree
   pure submittedTxId

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/ChainSync.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/ChainSync.hs
@@ -322,8 +322,8 @@ updateCheckpoint SyncState {..} slot blockHash = do
 
 -- | Reset all state to genesis (initial state, empty tree, empty history).
 -- Persists the reset to SQLite so it survives a crash.
-resetToGenesis ∷ Ctx → BatcherState → SyncState → IO ()
-resetToGenesis ctx bs ss = do
+_resetToGenesis ∷ Ctx → BatcherState → SyncState → IO ()
+_resetToGenesis ctx bs ss = do
   let initLH = pure (nullUTxOHash @A @I)
   atomically $ do
     writeTVar (bsLedgerStateVar bs) initialState
@@ -340,7 +340,7 @@ resetToGenesis ctx bs ss = do
 -- Much faster than a full genesis resync when the checkpoint is recent.
 --
 -- If no checkpoint has been saved yet (ssCheckpointRef = ChainPointAtGenesis),
--- this behaves identically to 'resetToGenesis'.
+-- this behaves identically to a genesis reset.
 resetToCheckpoint ∷ Ctx → BatcherState → SyncState → IO ()
 resetToCheckpoint ctx bs ss = do
   checkpoint ← readIORef (ssCheckpointRef ss)

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Config.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Config.hs
@@ -3,11 +3,14 @@ module ZkFold.Cardano.Rollup.Aggregator.Config (
   ServerConfig (..),
   BatchConfig (..),
   ChainSyncStartPoint (..),
+  SyncMode (..),
 
   -- * Configuration Loading
   serverConfigOptionalFPIO,
   signingKeyFromServerConfig,
   coreConfigFromServerConfig,
+  resolveSyncMode,
+  resolveSyncModeFields,
 ) where
 
 import Control.Exception (throwIO)
@@ -63,6 +66,13 @@ data ChainSyncStartPoint = ChainSyncStartPoint
     (FromJSON, ToJSON)
     via CustomJSON '[FieldLabelModifier '[StripPrefix "cssp", LowerFirst]] ChainSyncStartPoint
 
+-- | Source of L1 rollup state updates for the batcher.
+data SyncMode = SyncNode | SyncLight
+  deriving stock (Eq, Generic, Show)
+  deriving
+    (FromJSON, ToJSON)
+    via CustomJSON '[ConstructorTagModifier '[StripPrefix "Sync", LowerFirst]] SyncMode
+
 -- | Batch processing configuration.
 data BatchConfig = BatchConfig
   { bcBatchTransactions ∷ !Natural
@@ -111,8 +121,11 @@ data ServerConfig = ServerConfig
   -- ^ API key.
   , scDbPath ∷ !FilePath
   -- ^ SQLite database file path for the transaction queue and ledger state.
-  , scNodeSocketPath ∷ !FilePath
-  -- ^ Path to the cardano-node socket. Used for chain sync.
+  , scSyncMode ∷ !(Maybe SyncMode)
+  -- ^ State sync mode. Defaults to node mode when 'scNodeSocketPath' is present,
+  -- otherwise light mode.
+  , scNodeSocketPath ∷ !(Maybe FilePath)
+  -- ^ Path to the cardano-node socket. Required in node sync mode.
   , scChainSyncStartPoint ∷ !(Maybe ChainSyncStartPoint)
   -- ^ Optional starting chain point for first-run chain sync.
   -- When absent, syncing begins from genesis. When present, this slot/hash
@@ -182,3 +195,15 @@ coreConfigFromServerConfig ServerConfig {..} =
     , cfgLogging = scLogging
     , cfgLogTiming = Nothing
     }
+
+resolveSyncMode ∷ ServerConfig → SyncMode
+resolveSyncMode ServerConfig {..} = resolveSyncModeFields scSyncMode scNodeSocketPath
+
+resolveSyncModeFields ∷ Maybe SyncMode → Maybe FilePath → SyncMode
+resolveSyncModeFields mSyncMode mNodeSocketPath =
+  fromMaybe inferredMode mSyncMode
+ where
+  inferredMode =
+    case mNodeSocketPath of
+      Just _ → SyncNode
+      Nothing → SyncLight

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Ctx.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Ctx.hs
@@ -54,8 +54,8 @@ data Ctx = Ctx
   -- ^ Batch processing configuration.
   , ctxDbPath ∷ !FilePath
   -- ^ SQLite database file path shared between server and batcher processes.
-  , ctxNodeSocketPath ∷ !FilePath
-  -- ^ Path to the cardano-node socket. Used for chain sync.
+  , ctxNodeSocketPath ∷ !(Maybe FilePath)
+  -- ^ Optional path to the cardano-node socket. Used only in node sync mode.
   }
 
 logDebug ∷ HasCallStack ⇒ Ctx → String → IO ()

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Persistence.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Persistence.hs
@@ -22,6 +22,7 @@ module ZkFold.Cardano.Rollup.Aggregator.Persistence (
   saveResetToGenesisDb,
   savePreimagesDb,
   saveBatchResultDb,
+  saveLightBatchResultDb,
   lookupPreimagesDb,
   lookupPreimagesByRefDb,
   getKnownRefsDb,
@@ -550,6 +551,45 @@ saveBatchResultDb dbPath preimageEntries txIds l1TxId = withConn dbPath $ \conn 
       (l1TxId, formatTimestamp now, length txIds)
     batchId ← lastInsertRowId conn
     -- 3. Mark txs as batched.
+    forM_ txIds $ \tid →
+      execute
+        conn
+        "UPDATE txs SET status='batched', batch_id=? WHERE id=?"
+        (batchId, tid)
+ where
+  toText ∷ ToJSON a ⇒ a → Text
+  toText = decodeUtf8 . toStrict . encode
+
+-- | Atomically persist a Maestro-only batch result.
+--
+-- Light mode has no ChainSync writer, so the batcher must save the post-batch
+-- state at the same time as it records the confirmed L1 batch and marks queued
+-- transactions as batched.
+saveLightBatchResultDb
+  ∷ FilePath
+  → State I
+  → Leaves Ud (FieldElement I)
+  → [(FieldElement I, OutputRef I, UTxO A I)]
+  → [Int64]
+  → Text
+  → IO ()
+saveLightBatchResultDb dbPath newState newLeafHashes preimageEntries txIds l1TxId = withConn dbPath $ \conn →
+  withTransaction conn $ do
+    execute
+      conn
+      "INSERT OR REPLACE INTO ledger_state (id, ledger_state, utxo_preimage) VALUES (1, ?, ?)"
+      (toText newState, toText newLeafHashes)
+    forM_ preimageEntries $ \(leafHash, ref, utxo) →
+      execute
+        conn
+        "INSERT OR IGNORE INTO utxo_preimages (leaf_hash, output_ref, utxo_data) VALUES (?, ?, ?)"
+        (toText leafHash, toText ref, toText utxo)
+    now ← getCurrentTime
+    execute
+      conn
+      "INSERT INTO batches (l1_tx_id, created_at, tx_count) VALUES (?, ?, ?)"
+      (l1TxId, formatTimestamp now, length txIds)
+    batchId ← lastInsertRowId conn
     forM_ txIds $ \tid →
       execute
         conn

--- a/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Run.hs
+++ b/rollup-aggregator-server/src/ZkFold/Cardano/Rollup/Aggregator/Run.hs
@@ -119,6 +119,10 @@ logConfig tag logInfoS ctx serverConfig = do
       <> show (coreConfigFromServerConfig serverConfig)
       <> "\nDB Path: "
       <> ctxDbPath ctx
+      <> "\nSync Mode: "
+      <> show (resolveSyncMode serverConfig)
+      <> "\nNode Socket Path: "
+      <> maybe "<none>" id (ctxNodeSocketPath ctx)
 
 runServer ∷ Maybe FilePath → IO ()
 runServer mConfigPath = withCtx mConfigPath $ \serverConfig ctx → do
@@ -170,8 +174,15 @@ runBatcher mConfigPath = withCtx mConfigPath $ \serverConfig ctx → do
   let logInfoS = gyLogInfo (ctxProviders ctx) mempty
   logConfig "Batcher" logInfoS ctx serverConfig
   batcherState ← initBatcherState (ctxDbPath ctx)
-  -- Start chain sync in background.
-  let socketPath = ctxNodeSocketPath ctx
-  logInfoS $ "Starting chain sync client (socket: " <> socketPath <> ")"
-  _chainSyncAsync ← startChainSync ctx batcherState socketPath (scChainSyncStartPoint serverConfig)
-  startBatcher ctx batcherState
+  let syncMode = resolveSyncMode serverConfig
+  case syncMode of
+    SyncNode → do
+      socketPath ← case ctxNodeSocketPath ctx of
+        Just path → pure path
+        Nothing → throwIO $ userError "nodeSocketPath is required when syncMode is node"
+      logInfoS $ "Starting chain sync client (socket: " <> socketPath <> ")"
+      _chainSyncAsync ← startChainSync ctx batcherState socketPath (scChainSyncStartPoint serverConfig)
+      startBatcher syncMode ctx batcherState
+    SyncLight → do
+      logInfoS "Starting batcher in light sync mode (Maestro-only, no local node)"
+      startBatcher syncMode ctx batcherState

--- a/rollup-aggregator-server/test/Main.hs
+++ b/rollup-aggregator-server/test/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import GeniusYield.Test.Privnet.Setup (cardanoDefaultTestnetOptionsConway, withPrivnet)
 import Test.Tasty (defaultMain, testGroup)
 
+import ZkFold.Cardano.Rollup.Aggregator.Test.Config (configTests)
 import ZkFold.Cardano.Rollup.Aggregator.Test.EndToEnd (endToEndTests)
 import ZkFold.Cardano.Rollup.Aggregator.Test.Validation (validationTests)
 
@@ -12,6 +13,7 @@ main =
     defaultMain $
       testGroup
         "rollup-aggregator-server-tests"
-        [ validationTests
+        [ configTests
+        , validationTests
         , endToEndTests setup
         ]

--- a/rollup-aggregator-server/test/ZkFold/Cardano/Rollup/Aggregator/Test/Config.hs
+++ b/rollup-aggregator-server/test/ZkFold/Cardano/Rollup/Aggregator/Test/Config.hs
@@ -1,0 +1,28 @@
+module ZkFold.Cardano.Rollup.Aggregator.Test.Config (configTests) where
+
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Char8 qualified as BS8
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
+import ZkFold.Cardano.Rollup.Aggregator.Config (SyncMode (..), resolveSyncModeFields)
+
+configTests ∷ TestTree
+configTests =
+  testGroup
+    "Config"
+    [ testCase "defaults to light mode without a node socket" $
+        assertEqual "sync mode" SyncLight (resolveSyncModeFields Nothing Nothing)
+    , testCase "defaults to node mode when a node socket is configured" $
+        assertEqual "sync mode" SyncNode (resolveSyncModeFields Nothing (Just "/tmp/node.socket"))
+    , testCase "explicit light mode overrides a configured socket" $
+        assertEqual "sync mode" SyncLight (resolveSyncModeFields (Just SyncLight) (Just "/tmp/node.socket"))
+    , testCase "decodes sync mode tags" $ do
+        assertDecode "\"light\"" SyncLight
+        assertDecode "\"node\"" SyncNode
+    ]
+
+assertDecode ∷ String → SyncMode → IO ()
+assertDecode raw expected =
+  case Aeson.eitherDecodeStrict (BS8.pack raw) of
+    Left err → assertFailure err
+    Right actual → assertEqual raw expected actual

--- a/rollup-aggregator-server/test/ZkFold/Cardano/Rollup/Aggregator/Test/EndToEnd.hs
+++ b/rollup-aggregator-server/test/ZkFold/Cardano/Rollup/Aggregator/Test/EndToEnd.hs
@@ -158,7 +158,7 @@ bridgeInOnlyTests setup =
                 , AggCtx.ctxRollupBuildInfo = buildInfo
                 , AggCtx.ctxBatchConfig = BatchConfig {bcBatchTransactions = 2, bcBatchIntervalSeconds = 60}
                 , AggCtx.ctxDbPath = dbPath
-                , AggCtx.ctxNodeSocketPath = nodeSocket
+                , AggCtx.ctxNodeSocketPath = Just nodeSocket
                 }
 
         -- Start ChainSync
@@ -248,7 +248,7 @@ fullFlowTests setup =
                     , AggCtx.ctxRollupBuildInfo = buildInfo
                     , AggCtx.ctxBatchConfig = BatchConfig {bcBatchTransactions = 2, bcBatchIntervalSeconds = 60}
                     , AggCtx.ctxDbPath = dbPath
-                    , AggCtx.ctxNodeSocketPath = nodeSocket
+                    , AggCtx.ctxNodeSocketPath = Just nodeSocket
                     }
 
             -- Start ChainSync so the Merkle tree and state are maintained.


### PR DESCRIPTION
## Summary
- add syncMode to support explicit Maestro-only light mode and full node mode
- make nodeSocketPath optional so serve can run without a Cardano node socket
- let the batcher commit confirmed light-mode batches locally after Maestro submission
- keep ChainSync behavior for node mode and add config coverage
- include warning cleanup for executable RTS options and unused ChainSync helper

## Verification
- EC2: cabal build --disable-shared --disable-executable-dynamic rollup-aggregator-server:exe:rollup-aggregator-server
- EC2: cabal build --disable-shared --disable-executable-dynamic rollup-aggregator-server:test:rollup-aggregator-server-tests
- Deployed demo config with syncMode: light and no nodeSocketPath
- Verified serve and batch both running in SyncLight
- Verified public endpoints: /v0/health, /v0/state, /v0/tx/parameters, /v0/txs/pending

## Notes
Local workstation build is blocked before project compilation by a GHC 9.12.2 Plutus/nothunks solver conflict. EC2 uses GHC 9.6.7 and built the change successfully.